### PR TITLE
docs: 自动更新目录结构和提交历史

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 - **Spring Cloud Alibaba**：阿里巴巴微服务框架学习笔记
 
 ## 目录结构
-最后更新时间：2024年12月19日 13:30:14
+最后更新时间：2024年12月19日 13:34:53
 
 ```
 .
@@ -186,15 +186,15 @@
 
 ## 最近提交
 
-```
-- 50e93c6 Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-- e730305 Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-- 4697028 Merge pull request #33 from Zengwenliang0416/auto-update-directory-tree-and-history (Wenliang Zeng, 2024-12-19)
-- 4d3f5e2 Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-- d956eae Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-- eaa7f85 docs: 更新目录结构和提交历史 (github-actions[bot], 2024-12-19)
-- 5d8b219 Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-- a2a8c97 Merge pull request #32 from Zengwenliang0416/directory-tree-and-history-updates-20241219-130409 (Wenliang Zeng, 2024-12-19)
-- 8676233 docs: 更新目录结构和提交历史 (github-actions[bot], 2024-12-19)
-- 400faab Update update-directory-tree.yml (Wenliang Zeng, 2024-12-19)
-```
+| Commit | Description | Author | Date |
+|--------|-------------|--------|------|
+| f43f19e | 🐛 fix: 更新工作流格式 | Zengwenliang0416 | 2024-12-19 13:34 |
+| 7e65aa9 | ✨ feat: 优化提交历史展现方式 | Zengwenliang0416 | 2024-12-19 13:32 |
+| 2d987f6 | Merge pull request #35 from Zengwenliang0416/directory-tree- | Wenliang Zeng | 2024-12-19 13:30 |
+| 3001148 | docs: 更新目录结构和提交历史 | github-actions[bot] | 2024-12-19 05:30 |
+| 50e93c6 | Update update-directory-tree.yml | Wenliang Zeng | 2024-12-19 13:29 |
+| e730305 | Update update-directory-tree.yml | Wenliang Zeng | 2024-12-19 13:22 |
+| 4697028 | Merge pull request #33 from Zengwenliang0416/auto-update-dir | Wenliang Zeng | 2024-12-19 13:16 |
+| 4d3f5e2 | Update update-directory-tree.yml | Wenliang Zeng | 2024-12-19 13:14 |
+| d956eae | Update update-directory-tree.yml | Wenliang Zeng | 2024-12-19 13:13 |
+| eaa7f85 | docs: 更新目录结构和提交历史 | github-actions[bot] | 2024-12-19 05:08 |


### PR DESCRIPTION
自动更新 README.md 中的目录结构和提交历史
    
    - 更新时间：2024年12月19日 13:34:54
    - 目录数量：-1
    - 文件数量：
    - 由 GitHub Actions 自动创建